### PR TITLE
Utilize node/npm for the dist build step.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Check the tests_* files:
 * [Stress](http://sole.github.io/Animated_GIF/tests_stress.html)
 * [Sample Interval](http://sole.github.io/Animated_GIF/tests_sample_interval.html)
 
+## Rebuild dist files
+
+To rebuild the files in `dist/`, use [NPM](http://nodejs.org/):
+```
+npm install
+npm run build
+```
+
 ## See it in action
 
 Some sites and apps using it:

--- a/build.js
+++ b/build.js
@@ -1,0 +1,29 @@
+// Builds the dist/ folder sources for browser usage.
+'use strict';
+
+var fs = require('fs');
+var browserify = require('browserify')();
+var uglify = require('uglify-js');
+
+function readSrc(file) {
+  return fs.readFileSync(require.resolve('./src/' + file));
+}
+
+function writeDist(file, contents) {
+  fs.writeFileSync(require.resolve('./dist/' + file), contents, { encoding: 'utf8' });
+}
+
+// Build Animated_GIF.js
+browserify.add(require.resolve('./src/main.js'));
+browserify.bundle(function (err, src) {
+  var minified = uglify.minify(src, { fromString: true });
+  writeDist('Animated_GIF.js', src);
+  writeDist('Animated_GIF.min.js', minified.code);
+});
+
+// Build Animated_GIF.worker.js
+var worker = readSrc('NeuQuant.js');
+worker += readSrc('quantizer.js');
+var minifiedWorker = uglify.minify(worker, { fromString: true });
+writeDist('Animated_GIF.worker.js', worker);
+writeDist('Animated_GIF.worker.min.js', minifiedWorker.code);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "Animated_GIF",
+  "version": "0.0.0",
+  "description": "Javascript library for creating animated GIFs",
+  "main": "index.js",
+  "scripts": {
+    "build": "node build.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sole/Animated_GIF"
+  },
+  "keywords": [
+    "animated",
+    "gif"
+  ],
+  "bugs": {
+    "url": "https://github.com/sole/Animated_GIF/issues"
+  },
+  "homepage": "https://github.com/sole/Animated_GIF",
+  "devDependencies": {
+    "browserify": "~3.20.0",
+    "uglify-js": "~2.4.10"
+  }
+}

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,6 +1,0 @@
-cat NeuQuant.js quantizer.js > ../dist/Animated_GIF.worker.js
-browserify main.js > ../dist/Animated_GIF.js
-
-# minified versions too
-uglifyjs ../dist/Animated_GIF.js > ../dist/Animated_GIF.min.js
-uglifyjs ../dist/Animated_GIF.worker.js > ../dist/Animated_GIF.worker.min.js


### PR DESCRIPTION
This removes a dependency on a unix-like environment for building the dist files, and makes it easier to pull in the necessary build dependencies (browserify, uglify).
